### PR TITLE
Fake PR to get Charles' attention.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,8 @@ Buildbot is based on original work from `Brian Warner
 
 Buildbot consists of several components:
 
+Hello
+
 * master
 * worker
 * www/base


### PR DESCRIPTION
Hey Chuck, 

I made this fake pull request to hopefully get in touch with you.

I hope all is well! I heard of the lay offs at IMVU. Are you still there?

I remember you helped me solve a problem due to canvas being `display:inline` on the Sticker Creator 2, and changing it to `display:block` fixed it.

I'm having a similar issue, and I thought you might know why. Here's two pens:

https://codepen.io/trusktr/pen/WXdrdK

https://codepen.io/trusktr/pen/WXdvVr

The difference between them is that in the second pen the `<canvas>` is `display:block` which causes the pink square to move up slightly into the expected position covering the teal square behind it.

(the teal square is drawn in the canvas).

Why does setting the canvas to display:block fix the problem of the pink square being pushed down when perspective is applied.

When there is no perspective, there is no need to change the canvas to `display:block`, and in this case the pink square fully covers the teal square in the center of the view as expected (twhen perspective is applied but the canvas is inline the pink square shifts downward):

https://codepen.io/trusktr/pen/NwXxyB

When I look at the Inspector, I see that the body is slightly bigger due to the blue highlight of the Inspector, although the Inspector shows the same numerical value for the height of the body in both cases. If the body is bigger, then it makes sense that the pink square is pushed downward based on it's `top:50%` position.

But if the body is taller, why does Chrome report the same numerical value in both cases when you hover on the body element?

Do you know what's going on here? What supposed to be happening? Is Chrome Inspector reporting incorrect values?